### PR TITLE
[FIX] Allow iframe desktop-capture for BBB

### DIFF
--- a/app/videobridge/client/views/bbbLiveView.html
+++ b/app/videobridge/client/views/bbbLiveView.html
@@ -1,3 +1,3 @@
 <template name="bbbLiveView">
-	<iframe allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"  allow="geolocation; microphone; camera" src="{{source}}" width="380" height="400" frameborder="0"></iframe>
+	<iframe allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"  allow="geolocation; microphone; camera; display-capture" src="{{source}}" width="380" height="400" frameborder="0"></iframe>
 </template>


### PR DESCRIPTION
<!-- INSTRUCTION: Your Pull Request name should start with one of the following tags -->
<!-- [NEW] For new features -->
<!-- [FIX] For bug fixes -->
<!-- [BREAK] For pull requests including breaking changes -->

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #16972

<!-- INSTRUCTION: Link to a https://github.com/RocketChat/docs PR with added/updated documentation or an update to the missing/outdated documentation list, see https://rocket.chat/docs/contributing/documentation/  -->

The iframe used to embed BBB Video Chat allow for acces to geolocation, microphone and camera. Screen sharing is not allowed. However BBB offers to share your screen in the videoconference so it should be allowed for the iframe to request screen-sharing
